### PR TITLE
Add global prefix to be 'api'

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ dotenv.config();
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
   if (process.env.NODE_ENV === 'production') {
     app.use(helmet());
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,8 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5", // running on Node 16 latest, no reason to not use ES2021 target
-    "lib": ["ES2019"],
+    "target": "ES2020", // running on Node 16 latest, no reason to not use ES2021 target
+    "lib": ["ES2021"],
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
 - [ ] Added global prefix to be `"api"`
 - [ ] Switched to ES6 compiled output
 
 ---
 
 Switching to native ES6 output has the benefit of using native promises with `async/await`, arrow functions etc.